### PR TITLE
Fix: Add platform versions to Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,6 +5,7 @@ import PackageDescription
 
 let package = Package(
     name: "FlowLayout",
+    platforms: [.iOS(.v16), .macOS(.v12), .watchOS(.v9), .tvOS(.v16)],
     products: [
         // Products define the executables and libraries a package produces, making them visible to other packages.
         .library(


### PR DESCRIPTION
# Description

- Opening FlowLayout project in Xcode 16.2 encounters numerous API availability errors
- such as:
    - Alignment is only available in iOS 13.0 or newer
    - ProposedViewSize is only available in iOS 16.0 or newer
- These errors also occur when import FlowLayout into another project in Swift Package Manager
- Add iOS 16 and platform equivalents to solve this availability
- Platform versions fetched from https://xcodereleases.com/